### PR TITLE
fix(xml) Fix for empty LodLow XML node being added to exported xml files.

### DIFF
--- a/cwxml/element.py
+++ b/cwxml/element.py
@@ -8,7 +8,7 @@ from numpy import float32
 
 
 def remove_elements_with_no_attributes(elem):
-    for child in elem:
+    for child in list(elem):
         remove_elements_with_no_attributes(child)
         
         if child.text or len(child.attrib) > 0:


### PR DESCRIPTION
Fixed issue where a empty `<LodLow />`  xml node would be added to the ydr.xml or ydd.xml on export. 

This pull request may also fix any other additional issues related to empty xml nodes in exported XMLs in Sollumz RDR.