### PR TITLE
add: CExtensionDefScriptEntityId extention

### DIFF
--- a/cwxml/ymap.py
+++ b/cwxml/ymap.py
@@ -224,6 +224,12 @@ class ExtensionExpression(Extension):
         self.intialize_on_collision = ValueProperty(
             "initialiseOnCollision", False)
 
+class ExtensionScriptEntityId(Extension):
+    type = "CExtensionDefScriptEntityId"
+
+    def __init__(self):
+        super().__init__()
+        self.scipt_id = TextProperty("Id")
 
 class ExtensionLightShaft(Extension):
     type = "CExtensionDefLightShaft"
@@ -267,7 +273,6 @@ class ExtensionDoor(Extension):
         self.limit_angle = ValueProperty("limitAngle", False)
         self.door_target_ratio = ValueProperty("doorTargetRatio")
         self.audio_hash = TextProperty("audioHash")
-
 
 class ExtensionSpawnPoint(Extension):
     type = "CExtensionDefSpawnPoint"
@@ -375,6 +380,8 @@ class ExtensionsList(ListProperty):
             return ExtensionWindDisturbance
         elif ext_type == ExtensionProcObject.type:
             return ExtensionProcObject
+        elif ext_type == ExtensionScriptEntityId.type:
+            return ExtensionScriptEntityId
 
         return None
 

--- a/ytyp/properties/extensions.py
+++ b/ytyp/properties/extensions.py
@@ -19,6 +19,7 @@ class ExtensionType(str, Enum):
     WIND_DISTURBANCE = "CExtensionDefWindDisturbance"
     PROC_OBJECT = "CExtensionDefProcObject"
     EXPRESSION = "CExtensionDefExpression"
+    SCRIPT_ID = "CExtensionDefScriptEntityId"
 
 
 ExtensionTypeEnumItems = (
@@ -35,6 +36,7 @@ ExtensionTypeEnumItems = (
     (ExtensionType.WIND_DISTURBANCE, "Wind Disturbance", "", 10),
     (ExtensionType.PROC_OBJECT, "Procedural Object", "", 11),
     (ExtensionType.EXPRESSION, "Expression", "", 12),
+    (ExtensionType.SCRIPT_ID, "Script ID", "", 13),
 )
 
 
@@ -85,7 +87,6 @@ class DoorExtensionProperties(bpy.types.PropertyGroup, BaseExtensionProperties):
     door_target_ratio: bpy.props.FloatProperty(
         name="Door Target Ratio", min=0)
     audio_hash: bpy.props.StringProperty(name="Audio Hash")
-
 
 class ParticleExtensionProperties(bpy.types.PropertyGroup, BaseExtensionProperties):
     offset_rotation: bpy.props.FloatVectorProperty(
@@ -146,7 +147,9 @@ class ExpressionExtensionProperties(bpy.types.PropertyGroup, BaseExtensionProper
         name="Creature Metadata Name")
     initialize_on_collision: bpy.props.BoolProperty(
         name="Initialize on Collision")
-
+    
+class ScriptIDExtensionProperties(bpy.types.PropertyGroup, BaseExtensionProperties):
+    scipt_id: bpy.props.StringProperty(name="Script ID")
 
 class LightShaftExtensionProperties(bpy.types.PropertyGroup, BaseExtensionProperties):
     density_type: bpy.props.EnumProperty(items=LightShaftDensityTypeEnumItems, name="Density Type")
@@ -298,6 +301,8 @@ class ExtensionProperties(bpy.types.PropertyGroup):
             return self.explosion_extension_properties
         elif self.extension_type == ExtensionType.EXPRESSION:
             return self.expression_extension_properties
+        elif self.extension_type == ExtensionType.SCRIPT_ID:
+            return self.scriptid_extension_properties
         elif self.extension_type == ExtensionType.LADDER:
             return self.ladder_extension_properties
         elif self.extension_type == ExtensionType.LIGHT_SHAFT:
@@ -330,6 +335,8 @@ class ExtensionProperties(bpy.types.PropertyGroup):
         type=BuoyancyExtensionProperties)
     expression_extension_properties: bpy.props.PointerProperty(
         type=ExpressionExtensionProperties)
+    scriptid_extension_properties: bpy.props.PointerProperty(
+        type=ScriptIDExtensionProperties)
     light_shaft_extension_properties: bpy.props.PointerProperty(
         type=LightShaftExtensionProperties)
     spawn_point_extension_properties: bpy.props.PointerProperty(


### PR DESCRIPTION
The “**CExtensionDefScriptEntityId**” extension can be used to assign an id to the **CEntityDef** in order to lock/act with a gate via sript, for example. (id -> hash)

For example

```xml
    <Item type="CEntityDef">
     <archetypeName>p_door35x</archetypeName>
     <flags value="1572897" />
     <id value="0x0000000000000000" />
     <position x="4.030029" y="4.147226" z="-4.021069" />
     <rotation x="0" y="0" z="-0.707107" w="0.707107" />
     <scaleXY value="1" />
     <scaleZ value="1" />
     <parentIndex value="-1" />
     <lodDist value="80" />
     <childLodDist value="80" />
     <lodLevel>LODTYPES_DEPTH_ORPHANHD</lodLevel>
     <numChildren value="0" />
     <priorityLevel>PRI_REQUIRED</priorityLevel>
     <extensions>
      <Item type="CExtensionDefDoor">
       <name>p_door35x</name>
       <offsetPosition x="0" y="0" z="0" />
       <autoOpens value="False" />
       <enableLimitAngle value="True" />
       <EFwMwAA_0x091A42D0 value="False" />
       <startsLocked value="False" />
       <canBreak value="False" />
       <PkpciBA_0xA37CAB71 value="False" />
       <dKbmTLA_0xCFE37BDB value="1.570796" />
       <nuskEbA_0xA0CF3C8D value="1.570796" />
       <RbUnQLA_0x9C555ECF value="0" />
       <OPkNlHA_0xBCA0289E value="0" />
       <doorTargetRatio value="0" />
       <audioHash>NQiTaMA_0xE11B1F68</audioHash>
       <doorTags>
        <Item />
       </doorTags>
      </Item>
      <Item type="CExtensionDefScriptEntityId">
       <name>p_door35x</name>
       <offsetPosition x="0" y="0" z="0" />
       <Id>RzPmzAA_0x020687F3</Id>
      </Item>
     </extensions>
     <powerGridId value="0" />
     <tintValue value="0" />
     <blendAgeLayer value="255" />
     <blendAgeDirt value="255" />
    </Item>
    ```